### PR TITLE
Feature/article confirmation

### DIFF
--- a/test/controllers/article_controller_test.exs
+++ b/test/controllers/article_controller_test.exs
@@ -2,8 +2,8 @@ defmodule EspiDni.ArticleControllerTest do
   use EspiDni.ConnCase
 
   alias EspiDni.Article
-  @valid_attrs %{url: "some content"}
-  @invalid_attrs %{}
+  @valid_attrs %{url: "http://www.example.com"}
+  @invalid_attrs %{url: "invalid"}
 
   test "lists all entries on index", %{conn: conn} do
     conn = get conn, article_path(conn, :index)
@@ -27,7 +27,7 @@ defmodule EspiDni.ArticleControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    article = Repo.insert! %Article{}
+    article = Repo.insert! %Article{url: "http://www.example.com"}
     conn = get conn, article_path(conn, :show, article)
     assert html_response(conn, 200) =~ "Show article"
   end
@@ -39,26 +39,26 @@ defmodule EspiDni.ArticleControllerTest do
   end
 
   test "renders form for editing chosen resource", %{conn: conn} do
-    article = Repo.insert! %Article{}
+    article = Repo.insert! %Article{url: "http://www.example.com"}
     conn = get conn, article_path(conn, :edit, article)
     assert html_response(conn, 200) =~ "Edit article"
   end
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-    article = Repo.insert! %Article{}
+    article = Repo.insert! %Article{url: "http://www.something.com"}
     conn = put conn, article_path(conn, :update, article), article: @valid_attrs
     assert redirected_to(conn) == article_path(conn, :show, article)
     assert Repo.get_by(Article, @valid_attrs)
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    article = Repo.insert! %Article{}
+    article = Repo.insert! %Article{url: "http://www.example.com"}
     conn = put conn, article_path(conn, :update, article), article: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit article"
   end
 
   test "deletes chosen resource", %{conn: conn} do
-    article = Repo.insert! %Article{}
+    article = Repo.insert! %Article{url: "http://www.something.com"}
     conn = delete conn, article_path(conn, :delete, article)
     assert redirected_to(conn) == article_path(conn, :index)
     refute Repo.get(Article, article.id)

--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule EspiDni.PageControllerTest do
-  use EspiDni.ConnCase
+  use EspiDni.ConnCase, async: true
 
   test "GET /", %{conn: conn} do
     conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    assert html_response(conn, 200) =~ "Welcome"
   end
 end

--- a/test/controllers/slack_article_controller_test.exs
+++ b/test/controllers/slack_article_controller_test.exs
@@ -7,7 +7,7 @@ defmodule EspiDni.SlackArticleControllerTest do
   end
 
   test "returns a 401 for an invalid token", %{conn: conn} do
-    params = %{ command: "/add", token: "invalid" }
+    params = %{command: "/add", token: "invalid"}
     conn = post conn, slack_article_path(conn, :new), params
 
     assert conn.status == 401

--- a/test/controllers/slack_article_controller_test.exs
+++ b/test/controllers/slack_article_controller_test.exs
@@ -33,7 +33,7 @@ defmodule EspiDni.SlackArticleControllerTest do
     params = %{command: "/add", token: slack_token, user_id: user.slack_id, text: "http://example.com" }
     conn = post conn, slack_article_path(conn, :new), params
 
-    assert body = json_response(conn, 200)
+    body = json_response(conn, 200)
     assert "Okay, you'd like to register the article at http://example.com?" =~ body["text"]
   end
 end

--- a/test/controllers/slack_message_controller_test.exs
+++ b/test/controllers/slack_message_controller_test.exs
@@ -1,0 +1,67 @@
+defmodule EspiDni.SlackMessageControllerTest do
+  use EspiDni.ConnCase
+
+  setup do
+    user = insert_team |> insert_user
+    {:ok, conn: conn, user: user}
+  end
+
+  test "returns a 401 for an invalid token", %{conn: conn} do
+    params = %{ payload: Poison.encode!(%{"token" => "invalid"})}
+    conn = post conn, slack_message_path(conn, :new), params
+
+    assert conn.status == 401
+    assert conn.resp_body =~ "Unauthorized"
+  end
+
+  test "returns a 404 for an unknown user", %{conn: conn} do
+    params = %{ payload: Poison.encode!(%{"token" => slack_token, user_id: "invalid"})}
+    conn = post conn, slack_message_path(conn, :new), params
+
+    assert conn.status == 404
+    assert conn.resp_body =~ "Unknown User"
+  end
+
+  test "returns an error for an unknown callback", %{conn: conn, user: user} do
+    payload = Poison.encode!(
+      %{
+          token: slack_token,
+          user: %{ id: user.slack_id},
+          callback_id: "invalid"
+      }
+    )
+    conn = post conn, slack_message_path(conn, :new), %{ payload: payload}
+
+    assert conn.status == 400
+    assert conn.resp_body =~ "Unknown Action"
+  end
+
+  test "returns a message for a 'no' confirm_article action", %{conn: conn, user: user} do
+    payload = Poison.encode!(
+      %{
+        token: slack_token,
+        user: %{ id: user.slack_id},
+        callback_id: "confirm_article",
+        actions: [ %{name: "no", value: "url"} ]
+      }
+    )
+    conn = post conn, slack_message_path(conn, :new), %{ payload: payload}
+
+    assert text_response(conn, 200) =~ "ok, can you try adding it with `/add` again please?"
+  end
+
+  test "saves article and returns a message for a 'yes' confirm_article action", %{conn: conn, user: user} do
+    payload = Poison.encode!(
+      %{
+        token: slack_token,
+        user: %{ id: user.slack_id},
+        callback_id: "confirm_article",
+        actions: [ %{name: "yes", value: "http://www.example.com"} ]
+      }
+    )
+    conn = post conn, slack_message_path(conn, :new), %{ payload: payload}
+    assert Repo.get_by(EspiDni.Article, url: "http://www.example.com")
+
+    assert text_response(conn, 200) =~ "ok, great, I've registered http://www.example.com"
+  end
+end

--- a/test/controllers/slack_message_controller_test.exs
+++ b/test/controllers/slack_message_controller_test.exs
@@ -7,7 +7,7 @@ defmodule EspiDni.SlackMessageControllerTest do
   end
 
   test "returns a 401 for an invalid token", %{conn: conn} do
-    params = %{ payload: Poison.encode!(%{"token" => "invalid"})}
+    params = %{payload: Poison.encode!(%{"token" => "invalid"})}
     conn = post conn, slack_message_path(conn, :new), params
 
     assert conn.status == 401
@@ -15,7 +15,7 @@ defmodule EspiDni.SlackMessageControllerTest do
   end
 
   test "returns a 404 for an unknown user", %{conn: conn} do
-    params = %{ payload: Poison.encode!(%{"token" => slack_token, user_id: "invalid"})}
+    params = %{payload: Poison.encode!(%{"token" => slack_token, user_id: "invalid"})}
     conn = post conn, slack_message_path(conn, :new), params
 
     assert conn.status == 404
@@ -26,11 +26,11 @@ defmodule EspiDni.SlackMessageControllerTest do
     payload = Poison.encode!(
       %{
           token: slack_token,
-          user: %{ id: user.slack_id},
+          user: %{id: user.slack_id},
           callback_id: "invalid"
       }
     )
-    conn = post conn, slack_message_path(conn, :new), %{ payload: payload}
+    conn = post conn, slack_message_path(conn, :new), %{payload: payload}
 
     assert conn.status == 400
     assert conn.resp_body =~ "Unknown Action"
@@ -40,12 +40,12 @@ defmodule EspiDni.SlackMessageControllerTest do
     payload = Poison.encode!(
       %{
         token: slack_token,
-        user: %{ id: user.slack_id},
+        user: %{id: user.slack_id},
         callback_id: "confirm_article",
         actions: [ %{name: "no", value: "url"} ]
       }
     )
-    conn = post conn, slack_message_path(conn, :new), %{ payload: payload}
+    conn = post conn, slack_message_path(conn, :new), %{payload: payload}
 
     assert text_response(conn, 200) =~ "ok, can you try adding it with `/add` again please?"
   end
@@ -54,12 +54,12 @@ defmodule EspiDni.SlackMessageControllerTest do
     payload = Poison.encode!(
       %{
         token: slack_token,
-        user: %{ id: user.slack_id},
+        user: %{id: user.slack_id},
         callback_id: "confirm_article",
         actions: [ %{name: "yes", value: "http://www.example.com"} ]
       }
     )
-    conn = post conn, slack_message_path(conn, :new), %{ payload: payload}
+    conn = post conn, slack_message_path(conn, :new), %{payload: payload}
     assert Repo.get_by(EspiDni.Article, url: "http://www.example.com")
 
     assert text_response(conn, 200) =~ "ok, great, I've registered http://www.example.com"

--- a/test/controllers/team_controller_test.exs
+++ b/test/controllers/team_controller_test.exs
@@ -3,7 +3,7 @@ defmodule EspiDni.TeamControllerTest do
 
   alias EspiDni.Team
   @valid_attrs %{slack_id: "some content", token: "some content", name: "teamname", url: "some content"}
-  @invalid_attrs %{ token: "", slack_id: "", name: "" }
+  @invalid_attrs %{token: "", slack_id: "", name: ""}
 
   setup do
     team = insert_team

--- a/test/controllers/team_controller_test.exs
+++ b/test/controllers/team_controller_test.exs
@@ -2,8 +2,13 @@ defmodule EspiDni.TeamControllerTest do
   use EspiDni.ConnCase
 
   alias EspiDni.Team
-  @valid_attrs %{slack_id: "some content", token: "some content", url: "some content"}
-  @invalid_attrs %{}
+  @valid_attrs %{slack_id: "some content", token: "some content", name: "teamname", url: "some content"}
+  @invalid_attrs %{ token: "", slack_id: "", name: "" }
+
+  setup do
+    team = insert_team
+    {:ok, conn: conn, team: team}
+  end
 
   test "lists all entries on index", %{conn: conn} do
     conn = get conn, team_path(conn, :index)
@@ -26,8 +31,7 @@ defmodule EspiDni.TeamControllerTest do
     assert html_response(conn, 200) =~ "New team"
   end
 
-  test "shows chosen resource", %{conn: conn} do
-    team = Repo.insert! %Team{}
+  test "shows chosen resource", %{conn: conn, team: team} do
     conn = get conn, team_path(conn, :show, team)
     assert html_response(conn, 200) =~ "Show team"
   end
@@ -38,27 +42,23 @@ defmodule EspiDni.TeamControllerTest do
     end
   end
 
-  test "renders form for editing chosen resource", %{conn: conn} do
-    team = Repo.insert! %Team{}
+  test "renders form for editing chosen resource", %{conn: conn, team: team} do
     conn = get conn, team_path(conn, :edit, team)
     assert html_response(conn, 200) =~ "Edit team"
   end
 
-  test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-    team = Repo.insert! %Team{}
+  test "updates chosen resource and redirects when data is valid", %{conn: conn, team: team} do
     conn = put conn, team_path(conn, :update, team), team: @valid_attrs
     assert redirected_to(conn) == team_path(conn, :show, team)
     assert Repo.get_by(Team, @valid_attrs)
   end
 
-  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    team = Repo.insert! %Team{}
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn, team: team} do
     conn = put conn, team_path(conn, :update, team), team: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit team"
   end
 
-  test "deletes chosen resource", %{conn: conn} do
-    team = Repo.insert! %Team{}
+  test "deletes chosen resource", %{conn: conn, team: team} do
     conn = delete conn, team_path(conn, :delete, team)
     assert redirected_to(conn) == team_path(conn, :index)
     refute Repo.get(Team, team.id)

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -2,8 +2,14 @@ defmodule EspiDni.UserControllerTest do
   use EspiDni.ConnCase
 
   alias EspiDni.User
-  @valid_attrs %{team_id: 1, email: "some content", name: "some content", slack_id: "some content", timezone: "some content", username: "some content"}
-  @invalid_attrs %{}
+  @valid_attrs %{email: "some content", name: "some content", slack_id: "some content", timezone: "some content", username: "some content"}
+  @invalid_attrs %{slack_id: "", team_id: ""}
+
+  setup do
+    team = insert_team
+    user = insert_user(team)
+    {:ok, conn: conn, team: team, user: user}
+  end
 
   test "lists all entries on index", %{conn: conn} do
     conn = get conn, user_path(conn, :index)
@@ -15,8 +21,8 @@ defmodule EspiDni.UserControllerTest do
     assert html_response(conn, 200) =~ "New user"
   end
 
-  test "creates resource and redirects when data is valid", %{conn: conn} do
-    conn = post conn, user_path(conn, :create), user: @valid_attrs
+  test "creates resource and redirects when data is valid", %{conn: conn, team: team} do
+    conn = post conn, user_path(conn, :create), user: Map.merge(@valid_attrs, %{team_id: team.id})
     assert redirected_to(conn) == user_path(conn, :index)
     assert Repo.get_by(User, @valid_attrs)
   end
@@ -26,8 +32,7 @@ defmodule EspiDni.UserControllerTest do
     assert html_response(conn, 200) =~ "New user"
   end
 
-  test "shows chosen resource", %{conn: conn} do
-    user = Repo.insert! %User{}
+  test "shows chosen resource", %{conn: conn, user: user} do
     conn = get conn, user_path(conn, :show, user)
     assert html_response(conn, 200) =~ "Show user"
   end
@@ -38,27 +43,23 @@ defmodule EspiDni.UserControllerTest do
     end
   end
 
-  test "renders form for editing chosen resource", %{conn: conn} do
-    user = Repo.insert! %User{}
+  test "renders form for editing chosen resource", %{conn: conn, user: user} do
     conn = get conn, user_path(conn, :edit, user)
     assert html_response(conn, 200) =~ "Edit user"
   end
 
-  test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-    user = Repo.insert! %User{}
+  test "updates chosen resource and redirects when data is valid", %{conn: conn, user: user} do
     conn = put conn, user_path(conn, :update, user), user: @valid_attrs
     assert redirected_to(conn) == user_path(conn, :show, user)
     assert Repo.get_by(User, @valid_attrs)
   end
 
-  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    user = Repo.insert! %User{}
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn, user: user} do
     conn = put conn, user_path(conn, :update, user), user: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit user"
   end
 
-  test "deletes chosen resource", %{conn: conn} do
-    user = Repo.insert! %User{}
+  test "deletes chosen resource", %{conn: conn, user: user} do
     conn = delete conn, user_path(conn, :delete, user)
     assert redirected_to(conn) == user_path(conn, :index)
     refute Repo.get(User, user.id)

--- a/test/models/article_test.exs
+++ b/test/models/article_test.exs
@@ -16,7 +16,7 @@ defmodule EspiDni.ArticleTest do
     refute changeset.valid?
   end
 
-  test "changeset with url missing" do
+  test "changeset with url missing is invalid" do
     changeset = Article.changeset(%Article{}, %{})
     refute changeset.valid?
   end

--- a/test/models/article_test.exs
+++ b/test/models/article_test.exs
@@ -15,4 +15,9 @@ defmodule EspiDni.ArticleTest do
     changeset = Article.changeset(%Article{}, @invalid_attrs)
     refute changeset.valid?
   end
+
+  test "changeset with url missing" do
+    changeset = Article.changeset(%Article{}, %{})
+    refute changeset.valid?
+  end
 end

--- a/web/controllers/slack_messages_controller.ex
+++ b/web/controllers/slack_messages_controller.ex
@@ -1,0 +1,34 @@
+defmodule EspiDni.SlackMessageController do
+  use EspiDni.Web, :controller
+
+  alias EspiDni.Article
+
+  def new(conn, _params) do
+    handle_payload(conn, conn.assigns.payload)
+  end
+
+  defp handle_payload(conn, %{"callback_id" => "confirm_article"} = payload) do
+    action = List.first(payload["actions"])
+    case action do
+      %{"name" => "yes", "value" => url} ->
+        changeset = Article.changeset(
+          %Article{}, %{url: url, user: conn.assigns.current_user.id}
+        )
+        Repo.insert(changeset)
+        text conn, "ok, great, I've registered #{url}"
+      %{"name" => "no", "value" => _} ->
+        text conn, "ok, can you try adding it with `/add` again please?"
+    end
+  end
+
+  defp handle_payload(conn, _) do
+    conn
+    |> put_status(400)
+    |> text("Unknown Action")
+  end
+
+  defp response(payload) do
+    List.first(payload["actions"]) 
+  end
+
+end

--- a/web/models/article.ex
+++ b/web/models/article.ex
@@ -27,7 +27,8 @@ defmodule EspiDni.Article do
     validate_change changeset, field, fn _, url ->
       case url |> String.to_char_list |> :http_uri.parse do
         {:ok, _} -> []
-        {:error, msg} -> [{field, options[:message] || "#{url} is not a valid URL!"}]
+        {:error, msg} ->
+          [{field, options[:message] || "#{url} is not a valid URL!"}]
       end
     end
   end

--- a/web/models/article.ex
+++ b/web/models/article.ex
@@ -20,14 +20,14 @@ defmodule EspiDni.Article do
   def changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> validate_url(:url, message: "#{params.url} is not a valid URL!")
+    |> validate_url(:url)
   end
 
   def validate_url(changeset, field, options \\ []) do
     validate_change changeset, field, fn _, url ->
       case url |> String.to_char_list |> :http_uri.parse do
         {:ok, _} -> []
-        {:error, msg} -> [{field, options[:message] || "invalid url: #{inspect msg}"}]
+        {:error, msg} -> [{field, options[:message] || "#{url} is not a valid URL!"}]
       end
     end
   end

--- a/web/plugs/parse_slack_payload.ex
+++ b/web/plugs/parse_slack_payload.ex
@@ -6,7 +6,7 @@ defmodule EspiDni.Plugs.ParseSlackPayload do
 
   def call(conn = %Plug.Conn{params: %{"payload" => payload}}, _opts) do
     case Poison.decode(payload) do
-      { :ok, parsed_payload } ->
+      {:ok, parsed_payload} ->
         assign(conn, :payload, parsed_payload)
       _ ->
         conn

--- a/web/views/slack_article_view.ex
+++ b/web/views/slack_article_view.ex
@@ -22,7 +22,7 @@ defmodule EspiDni.SlackArticleView do
               name: "no",
               text: "Nope",
               type: "button",
-              value: "no"
+              value: "#{url}"
             }
           ]
         }


### PR DESCRIPTION
Adds slack_message_controller to handle interactive message buttons for article confirmation.
![aug-22-2016 16-39-28](https://cloud.githubusercontent.com/assets/85859/17858729/2235f954-6887-11e6-9915-c27adb733d85.gif)
