### PR TITLE
Feature/add page viewcounts

### DIFF
--- a/priv/repo/migrations/20160915102349_create_view_count.exs
+++ b/priv/repo/migrations/20160915102349_create_view_count.exs
@@ -9,6 +9,5 @@ defmodule EspiDni.Repo.Migrations.CreateViewCount do
       timestamps
     end
     create index(:view_counts, [:article_id])
-
   end
 end

--- a/priv/repo/migrations/20160915102349_create_view_count.exs
+++ b/priv/repo/migrations/20160915102349_create_view_count.exs
@@ -1,0 +1,14 @@
+defmodule EspiDni.Repo.Migrations.CreateViewCount do
+  use Ecto.Migration
+
+  def change do
+    create table(:view_counts) do
+      add :count, :integer, default: 0
+      add :article_id, references(:articles, on_delete: :delete_all)
+
+      timestamps
+    end
+    create index(:view_counts, [:article_id])
+
+  end
+end

--- a/priv/repo/migrations/20160915143609_add_path_to_articles.exs
+++ b/priv/repo/migrations/20160915143609_add_path_to_articles.exs
@@ -1,0 +1,9 @@
+defmodule EspiDni.Repo.Migrations.AddPathToArticles do
+  use Ecto.Migration
+
+  def change do
+    alter table(:articles) do
+      add :path, :string, null: false
+    end
+  end
+end

--- a/test/controllers/article_controller_test.exs
+++ b/test/controllers/article_controller_test.exs
@@ -5,6 +5,12 @@ defmodule EspiDni.ArticleControllerTest do
   @valid_attrs %{url: "http://www.example.com"}
   @invalid_attrs %{url: "invalid"}
 
+  setup do
+    user = insert_team |> insert_user
+    article = insert_article(user)
+    {:ok, conn: conn, article: article, user: user}
+  end
+
   test "lists all entries on index", %{conn: conn} do
     conn = get conn, article_path(conn, :index)
     assert html_response(conn, 200) =~ "Listing articles"
@@ -15,19 +21,22 @@ defmodule EspiDni.ArticleControllerTest do
     assert html_response(conn, 200) =~ "New article"
   end
 
-  test "creates resource and redirects when data is valid", %{conn: conn} do
+  test "creates resource and redirects when data is valid", %{user: user} do
+    conn = assign(conn(), :current_user, user)
     conn = post conn, article_path(conn, :create), article: @valid_attrs
+
     assert redirected_to(conn) == article_path(conn, :index)
     assert Repo.get_by(Article, @valid_attrs)
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+  test "does not create resource and renders errors when data is invalid", %{user: user} do
+    conn = assign(conn(), :current_user, user)
     conn = post conn, article_path(conn, :create), article: @invalid_attrs
+
     assert html_response(conn, 200) =~ "New article"
   end
 
-  test "shows chosen resource", %{conn: conn} do
-    article = Repo.insert! %Article{url: "http://www.example.com/path", path: "/path"}
+  test "shows chosen resource", %{conn: conn, article: article} do
     conn = get conn, article_path(conn, :show, article)
     assert html_response(conn, 200) =~ "Show article"
   end
@@ -38,28 +47,24 @@ defmodule EspiDni.ArticleControllerTest do
     end
   end
 
-  test "renders form for editing chosen resource", %{conn: conn} do
-    article = Repo.insert! %Article{url: "http://www.example.com/path", path: "/path"}
+  test "renders form for editing chosen resource", %{conn: conn, article: article} do
     conn = get conn, article_path(conn, :edit, article)
     assert html_response(conn, 200) =~ "Edit article"
   end
 
-  test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-    article = Repo.insert! %Article{url: "http://www.something.com/path", path: "/path"}
-
+  test "updates chosen resource and redirects when data is valid", %{conn: conn, article: article} do
     conn = put conn, article_path(conn, :update, article), article: @valid_attrs
+
     assert redirected_to(conn) == article_path(conn, :show, article)
     assert Repo.get_by(Article, @valid_attrs)
   end
 
-  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    article = Repo.insert! %Article{url: "http://www.example.com/path", path: "/path"}
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn, article: article} do
     conn = put conn, article_path(conn, :update, article), article: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit article"
   end
 
-  test "deletes chosen resource", %{conn: conn} do
-    article = Repo.insert! %Article{url: "http://www.something.com/path", path: "/path"}
+  test "deletes chosen resource", %{conn: conn, article: article} do
     conn = delete conn, article_path(conn, :delete, article)
     assert redirected_to(conn) == article_path(conn, :index)
     refute Repo.get(Article, article.id)

--- a/test/controllers/article_controller_test.exs
+++ b/test/controllers/article_controller_test.exs
@@ -27,7 +27,7 @@ defmodule EspiDni.ArticleControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    article = Repo.insert! %Article{url: "http://www.example.com"}
+    article = Repo.insert! %Article{url: "http://www.example.com/path", path: "/path"}
     conn = get conn, article_path(conn, :show, article)
     assert html_response(conn, 200) =~ "Show article"
   end
@@ -39,26 +39,27 @@ defmodule EspiDni.ArticleControllerTest do
   end
 
   test "renders form for editing chosen resource", %{conn: conn} do
-    article = Repo.insert! %Article{url: "http://www.example.com"}
+    article = Repo.insert! %Article{url: "http://www.example.com/path", path: "/path"}
     conn = get conn, article_path(conn, :edit, article)
     assert html_response(conn, 200) =~ "Edit article"
   end
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-    article = Repo.insert! %Article{url: "http://www.something.com"}
+    article = Repo.insert! %Article{url: "http://www.something.com/path", path: "/path"}
+
     conn = put conn, article_path(conn, :update, article), article: @valid_attrs
     assert redirected_to(conn) == article_path(conn, :show, article)
     assert Repo.get_by(Article, @valid_attrs)
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    article = Repo.insert! %Article{url: "http://www.example.com"}
+    article = Repo.insert! %Article{url: "http://www.example.com/path", path: "/path"}
     conn = put conn, article_path(conn, :update, article), article: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit article"
   end
 
   test "deletes chosen resource", %{conn: conn} do
-    article = Repo.insert! %Article{url: "http://www.something.com"}
+    article = Repo.insert! %Article{url: "http://www.something.com/path", path: "/path"}
     conn = delete conn, article_path(conn, :delete, article)
     assert redirected_to(conn) == article_path(conn, :index)
     refute Repo.get(Article, article.id)

--- a/test/controllers/article_controller_test.exs
+++ b/test/controllers/article_controller_test.exs
@@ -24,7 +24,6 @@ defmodule EspiDni.ArticleControllerTest do
   test "creates resource and redirects when data is valid", %{user: user} do
     conn = assign(conn(), :current_user, user)
     conn = post conn, article_path(conn, :create), article: @valid_attrs
-
     assert redirected_to(conn) == article_path(conn, :index)
     assert Repo.get_by(Article, @valid_attrs)
   end
@@ -32,7 +31,6 @@ defmodule EspiDni.ArticleControllerTest do
   test "does not create resource and renders errors when data is invalid", %{user: user} do
     conn = assign(conn(), :current_user, user)
     conn = post conn, article_path(conn, :create), article: @invalid_attrs
-
     assert html_response(conn, 200) =~ "New article"
   end
 
@@ -54,7 +52,6 @@ defmodule EspiDni.ArticleControllerTest do
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn, article: article} do
     conn = put conn, article_path(conn, :update, article), article: @valid_attrs
-
     assert redirected_to(conn) == article_path(conn, :show, article)
     assert Repo.get_by(Article, @valid_attrs)
   end

--- a/test/models/article_test.exs
+++ b/test/models/article_test.exs
@@ -3,12 +3,22 @@ defmodule EspiDni.ArticleTest do
 
   alias EspiDni.Article
 
-  @valid_attrs %{url: "http://www.example.com/foo"}
+  @valid_attrs %{url: "http://www.example.com/foo?param=bar"}
   @invalid_attrs %{url: "not a url"}
 
   test "changeset with valid attributes" do
     changeset = Article.changeset(%Article{}, @valid_attrs)
     assert changeset.valid?
+  end
+
+  test "changset sets the article path" do
+    changeset = Article.changeset(%Article{}, @valid_attrs)
+    assert get_change(changeset, :path) == "/foo"
+  end
+
+  test "changset sets the article path for a root url" do
+    changeset = Article.changeset(%Article{}, %{url: "http://www.example.com"})
+    assert get_change(changeset, :path) == "/"
   end
 
   test "changeset with invalid attributes" do

--- a/test/models/article_test.exs
+++ b/test/models/article_test.exs
@@ -3,7 +3,7 @@ defmodule EspiDni.ArticleTest do
 
   alias EspiDni.Article
 
-  @valid_attrs %{url: "http://www.example.com/foo?param=bar"}
+  @valid_attrs %{url: "http://www.example.com/foo?param=bar", user_id: 123}
   @invalid_attrs %{url: "not a url"}
 
   test "changeset with valid attributes" do

--- a/test/models/google_auth_handler_test.exs
+++ b/test/models/google_auth_handler_test.exs
@@ -4,6 +4,7 @@ defmodule EspiDni.GoogleAuthHandlerTest do
   alias EspiDni.GoogleAuthHandler
 
   @valid_params %{credentials: %{token: "atoken", refresh_token: "refresh_token"}}
+  @invalid_params %{credentials: %{}}
 
   setup do
     team = insert_team
@@ -16,5 +17,9 @@ defmodule EspiDni.GoogleAuthHandlerTest do
         assert team.google_token == "atoken"
         assert team.google_refresh_token == "refresh_token"
     end
+  end
+
+  test "something", %{team: team} do
+    assert GoogleAuthHandler.update_from_auth(team, @invalid_params) == {:error}
   end
 end

--- a/test/models/team_test.exs
+++ b/test/models/team_test.exs
@@ -11,6 +11,12 @@ defmodule EspiDni.TeamTest do
   }
   @invalid_attrs %{}
 
+  setup do
+    team = insert_team
+    user = insert_user(team)
+    {:ok, team: team, user: user}
+  end
+
   test "changeset with valid attributes" do
     changeset = Team.changeset(%Team{}, @valid_attrs)
     assert changeset.valid?
@@ -19,5 +25,16 @@ defmodule EspiDni.TeamTest do
   test "changeset with invalid attributes" do
     changeset = Team.changeset(%Team{}, @invalid_attrs)
     refute changeset.valid?
+  end
+
+  test "article_paths with no articles", %{team: team, user: user} do
+    assert Team.article_paths(team) == []
+  end
+
+  test "article_paths with articles", %{team: team, user: user} do
+    insert_article(user, %{path: "/foobar"})
+    insert_article(user, %{path: "/"})
+    insert_article(user, %{path: "/foo/baz/bar/"})
+    assert Enum.sort(Team.article_paths(team)) == Enum.sort(["/foobar", "/", "/foo/baz/bar/"])
   end
 end

--- a/test/models/view_count_test.exs
+++ b/test/models/view_count_test.exs
@@ -1,6 +1,5 @@
 defmodule EspiDni.ViewCountTest do
   use EspiDni.ModelCase
-
   alias EspiDni.ViewCount
 
   @valid_attrs %{count: 42, article_id: 1}

--- a/test/models/view_count_test.exs
+++ b/test/models/view_count_test.exs
@@ -1,0 +1,18 @@
+defmodule EspiDni.ViewCountTest do
+  use EspiDni.ModelCase
+
+  alias EspiDni.ViewCount
+
+  @valid_attrs %{count: 42, article_id: 1}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = ViewCount.changeset(%ViewCount{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = ViewCount.changeset(%ViewCount{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -27,6 +27,18 @@ defmodule EspiDni.TestHelpers do
     |> Repo.insert!()
   end
 
+  def insert_article(user, attrs \\ %{}) do
+    article_attrs = Map.merge(%{
+      url: "http://www.example.com/foobar",
+      path: "/somepath",
+      user: user,
+    }, attrs)
+
+    user
+    |> Ecto.build_assoc(:articles, article_attrs)
+    |> Repo.insert!()
+  end
+
   def slack_token do
     Application.get_env(:espi_dni, EspiDni.Plugs.RequireSlackToken)[:slack_token]
   end

--- a/web/controllers/article_controller.ex
+++ b/web/controllers/article_controller.ex
@@ -16,7 +16,8 @@ defmodule EspiDni.ArticleController do
   end
 
   def create(conn, %{"article" => article_params}) do
-    changeset = Article.changeset(%Article{}, article_params)
+    params = Map.merge(article_params, %{"user_id" => conn.assigns.current_user.id})
+    changeset = Article.changeset(%Article{}, params)
 
     case Repo.insert(changeset) do
       {:ok, _article} ->

--- a/web/controllers/slack_article_controller.ex
+++ b/web/controllers/slack_article_controller.ex
@@ -4,7 +4,7 @@ defmodule EspiDni.SlackArticleController do
   alias EspiDni.Article
 
   def new(conn, %{"command" => "/add", "text" => url} = params) do
-    changeset = Article.changeset(%Article{}, %{url: url, user: conn.assigns.current_user.id})
+    changeset = Article.changeset(%Article{}, %{url: url, user_id: conn.assigns.current_user.id})
     if changeset.valid? do
       render(conn, "confirm.json", url: url)
     else

--- a/web/controllers/slack_messages_controller.ex
+++ b/web/controllers/slack_messages_controller.ex
@@ -12,7 +12,7 @@ defmodule EspiDni.SlackMessageController do
     case action do
       %{"name" => "yes", "value" => url} ->
         changeset = Article.changeset(
-          %Article{}, %{url: url, user: conn.assigns.current_user.id}
+          %Article{}, %{url: url, user_id: conn.assigns.current_user.id}
         )
         Repo.insert(changeset)
         text conn, "ok, great, I've registered #{url}"

--- a/web/models/article.ex
+++ b/web/models/article.ex
@@ -3,13 +3,14 @@ defmodule EspiDni.Article do
 
   schema "articles" do
     field :url, :string
+    field :path, :string
     belongs_to :user, EspiDni.User
 
     timestamps
   end
 
   @required_fields ~w(url)
-  @optional_fields ~w()
+  @optional_fields ~w(path)
 
   @doc """
   Creates a changeset based on the `model` and `params`.
@@ -20,16 +21,32 @@ defmodule EspiDni.Article do
   def changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields, @optional_fields)
+    |> set_path()
     |> validate_url(:url)
   end
 
-  def validate_url(changeset, field, options \\ []) do
+  defp validate_url(changeset, field, options \\ []) do
     validate_change changeset, field, fn _, url ->
       case url |> String.to_char_list |> :http_uri.parse do
         {:ok, _} -> []
         {:error, msg} ->
           [{field, options[:message] || "#{url} is not a valid URL!"}]
       end
+    end
+  end
+
+  defp set_path(changeset) do
+    if url = get_change(changeset, :url) do
+      put_change(changeset, :path, extract_path(url))
+    else
+      changeset
+    end
+  end
+
+  defp extract_path(url) do
+    case URI.parse(url) do
+      %URI{path: nil} -> "/"
+      %URI{path: path} -> path
     end
   end
 end

--- a/web/models/article.ex
+++ b/web/models/article.ex
@@ -5,6 +5,7 @@ defmodule EspiDni.Article do
     field :url, :string
     field :path, :string
     belongs_to :user, EspiDni.User
+    has_many :view_counts, EspiDni.ViewCount
 
     timestamps
   end

--- a/web/models/article.ex
+++ b/web/models/article.ex
@@ -9,7 +9,7 @@ defmodule EspiDni.Article do
     timestamps
   end
 
-  @required_fields ~w(url)
+  @required_fields ~w(url user_id)
   @optional_fields ~w(path)
 
   @doc """

--- a/web/models/google_auth_handler.ex
+++ b/web/models/google_auth_handler.ex
@@ -6,16 +6,15 @@ defmodule EspiDni.GoogleAuthHandler do
   alias EspiDni.Team
   alias EspiDni.Repo
 
-  def update_from_auth(team, auth) do
+
+  def update_from_auth(team, %{credentials: %{token: token, refresh_token: refresh_token}}) do
     team
-    |> Team.changeset(google_params(auth))
+    |> Team.changeset(%{google_token: token, google_refresh_token: refresh_token})
     |> Repo.update
   end
 
-  defp google_params(auth) do
-    %{
-      google_token: auth.credentials.token,
-      google_refresh_token: auth.credentials.refresh_token
-    }
+  def update_from_auth(team, _) do
+    {:error}
   end
+
 end

--- a/web/models/team.ex
+++ b/web/models/team.ex
@@ -27,4 +27,13 @@ defmodule EspiDni.Team do
     |> cast(params, @required_fields, @optional_fields)
   end
 
+  def article_paths(team) do
+    EspiDni.Repo.all(
+      from article in EspiDni.Article,
+      join: user in EspiDni.User, on: user.id == article.user_id,
+      where: user.team_id == ^team.id,
+      select: article.path
+    )
+  end
+
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -8,6 +8,7 @@ defmodule EspiDni.User do
     field :timezone, :string
     field :name, :string
     belongs_to :team, EspiDni.Team
+    has_many :articles, EspiDni.Article
 
     timestamps
   end

--- a/web/models/view_count.ex
+++ b/web/models/view_count.ex
@@ -1,0 +1,24 @@
+defmodule EspiDni.ViewCount do
+  use EspiDni.Web, :model
+
+  schema "view_counts" do
+    field :count, :integer
+    belongs_to :article, EspiDni.Article
+
+    timestamps
+  end
+
+  @required_fields ~w(count article_id)
+  @optional_fields ~w()
+
+  @doc """
+  Creates a changeset based on the `model` and `params`.
+
+  If no params are provided, an invalid changeset is returned
+  with no validation performed.
+  """
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+  end
+end


### PR DESCRIPTION
Initial setup managing article viewcounts.
- Creates view_counts table
- Adds `path` to articles to make google analytic queries easier
- Tidies up `belongs_to`/`has_many` relations on existing models
