### PR TITLE
Feature/add google property

### DIFF
--- a/lib/espi_dni/google_analytics_client.ex
+++ b/lib/espi_dni/google_analytics_client.ex
@@ -1,0 +1,38 @@
+defmodule EspiDni.GoogleAnalyticsClient do
+
+  require Logger
+  alias EspiDni.GoogleWebProperty
+
+  @url "https://www.googleapis.com/analytics/v3/management/accounts"
+  @account_id "~all"
+  @properties_path "/webproperties"
+  @headers []
+
+  def get_properties(team) do
+    case HTTPoison.get(@url, @headers, params: request_params(team)) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: response}} ->
+        parse_properties(response)
+      {:ok, %HTTPoison.Response{status_code: 401, body: response}} ->
+        Logger.error "Authentication error #{inspect response}"
+        []
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        Logger.error "Google Analytics error #{inspect reason}"
+        []
+    end
+  end
+
+  defp parse_properties(response) do
+    case Poison.decode(response, as: %{"items" => [%GoogleWebProperty{}]}) do
+      {:ok, %{"items" => items}} -> items
+      _ -> []
+    end
+  end
+
+  defp request_params(team) do
+    %{"access_token" => team.google_token}
+  end
+
+  defp web_properties_url do
+    @url <> @account_id <> @properties_path
+  end
+end

--- a/priv/repo/migrations/20160920192402_add_property_id_to_teams.exs
+++ b/priv/repo/migrations/20160920192402_add_property_id_to_teams.exs
@@ -1,0 +1,9 @@
+defmodule EspiDni.Repo.Migrations.AddPropertyIdToTeams do
+  use Ecto.Migration
+
+  def change do
+    alter table(:teams) do
+      add :google_property_id, :integer
+    end
+  end
+end

--- a/web/models/google_web_property.ex
+++ b/web/models/google_web_property.ex
@@ -1,0 +1,4 @@
+defmodule EspiDni.GoogleWebProperty do
+  @derive [Poison.Encoder]
+  defstruct [:id, :name]
+end

--- a/web/models/team.ex
+++ b/web/models/team.ex
@@ -5,6 +5,7 @@ defmodule EspiDni.Team do
     field :slack_token,          :string
     field :google_token,         :string
     field :google_refresh_token, :string
+    field :google_property_id,   :integer
     field :name,                 :string
     field :url,                  :string
     field :slack_id,             :string
@@ -14,7 +15,7 @@ defmodule EspiDni.Team do
   end
 
   @required_fields ~w(slack_token name slack_id)
-  @optional_fields ~w(url google_token google_refresh_token)
+  @optional_fields ~w(url google_token google_refresh_token google_property_id)
 
   @doc """
   Creates a changeset based on the `model` and `params`.

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -10,6 +10,14 @@
       src="https://platform.slack-edge.com/img/sign_in_with_slack.png"
       srcset="https://platform.slack-edge.com/img/sign_in_with_slack.png 1x, https://platform.slack-edge.com/img/sign_in_with_slack@2x.png 2x"/>
   <% end %>
+
+  <%= if @current_team && @current_team.google_token do %>
+    <%= form_for team_changeset(@current_team), team_path(@conn, :update, @current_team), fn form -> %>
+      <%= select form, :google_property_id, web_properties(@current_team), class: "form-control", prompt: "Select Google Analytics Property" %>
+      <%= submit "Submit" %>
+    <% end %>
+  <% end %>
+
 </div>
 
 <div class="bottom">

--- a/web/views/page_view.ex
+++ b/web/views/page_view.ex
@@ -1,3 +1,15 @@
 defmodule EspiDni.PageView do
   use EspiDni.Web, :view
+
+  alias EspiDni.Team
+  alias EspiDni.GoogleAnalyticsClient
+
+  def web_properties(%Team{} = team) do
+    GoogleAnalyticsClient.get_properties(team)
+    |> Enum.map(&{&1.name, &1.id})
+  end
+
+  def team_changeset(%Team{} = team) do
+    EspiDni.Team.changeset(team, %{})
+  end
 end


### PR DESCRIPTION
Adds logic to set the web property ID for a teams google analytics account.
- Adds a module to call goole analytics api
- Parses the results on a form
- allows the team to update their account with web proprety id
