### PR TITLE
Sets buildpack config to export SLACK_TOKEN on deploy

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,2 +1,3 @@
 # Elixir version
 elixir_version=1.2.5
+config_vars_to_export=(DATABASE_URL SLACK_TOKEN)

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,5 +1,4 @@
 clean_cache=false
 compile="compile"
-config_vars_to_export=(DATABASE_URL)
 node_version=5.3.0
 phoenix_relative_path=.


### PR DESCRIPTION
Token needs to be available at compile-time

@edenspiekermann/backend This is the issue I discussed at todays backend check-in, the env var needs to be exported by the buildpack to be made available at compile time
