### PR TITLE
Feature/viewcount notification

### DIFF
--- a/lib/espi_dni/analytics_supervisor.ex
+++ b/lib/espi_dni/analytics_supervisor.ex
@@ -31,7 +31,7 @@ defmodule EspiDni.AnalyticsSupervisor do
     results = EspiDni.GoogleRealtimeClient.get_pageviews(team)
 
     for view_count_data <- results do
-      create_view_count(view_count_data, team)
+      EspiDni.ViewCountHandler.process_view_count(view_count_data, team)
     end
 
     queue_analytic_call(team)
@@ -42,25 +42,6 @@ defmodule EspiDni.AnalyticsSupervisor do
       from team in EspiDni.Team,
       where: not is_nil(team.google_token),
       where: not is_nil(team.google_property_id)
-    )
-  end
-
-  defp create_view_count(view_count_data, team) do
-    article_id = get_article_id(view_count_data.path, team)
-
-    if article_id do
-      ViewCount.changeset(%ViewCount{}, %{article_id: article_id, count: view_count_data.count})
-      |> Repo.insert!()
-    end
-  end
-
-  defp get_article_id(path, team) do
-    Repo.one(
-      from article in EspiDni.Article,
-      join: user in EspiDni.User, on: user.id == article.user_id,
-      where: user.team_id == ^team.id,
-      where: article.path == ^path,
-      select: article.id
     )
   end
 end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -24,3 +24,6 @@ msgstr ""
 
 msgid "Initial Greeting"
 msgstr ""
+
+msgid "Message Spike"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -24,3 +24,6 @@ msgstr ""
 msgid "Initial Greeting"
 msgstr "Hi! I'm POST. I help journalists by suggesting the right action at the right moment.\n\n"
   "Use the `/add` command to add a new article url."
+
+msgid "Message Spike"
+msgstr "Your article `%{article_url}` is very popular at the moment, the pageviews increased by %{count} in the last half an hour."

--- a/test/models/view_count_handler_test.exs
+++ b/test/models/view_count_handler_test.exs
@@ -1,0 +1,53 @@
+defmodule EspiDni.ViewCountHandlerTest do
+  use EspiDni.ModelCase
+  alias EspiDni.ViewCountHandler
+  alias EspiDni.ViewCount
+
+  setup do
+    team = insert_team
+    user = insert_user(team)
+    article = insert_article(user)
+
+    {:ok, team: team, article: article}
+  end
+
+  test "process_view_count creates a new viewcount for an existing article", %{team: team, article: article} do
+    view_count_data = %{path: article.path, count: 42}
+    ViewCountHandler.process_view_count(view_count_data, team)
+
+    view_count = Repo.one(from view_count in ViewCount, order_by: [desc: view_count.id], limit: 1)
+    assert view_count.count == 42
+    assert view_count.article_id == article.id
+  end
+
+  test "process_view_count does not create a record for an unknown path", %{team: team} do
+    view_count_data = %{path: "/unknown_path", count: 42}
+    ViewCountHandler.process_view_count(view_count_data, team)
+    assert Repo.one(from view_count in ViewCount, select: count(view_count.id)) == 0
+  end
+
+  test "process_view_count does not send message of min view count increase is not reached", %{team: team, article: article} do
+    Repo.insert!(ViewCount.changeset(%ViewCount{}, %{article_id: article.id, count: 5}))
+    view_count_data = %{path: article.path, count: 14}
+    result = ViewCountHandler.process_view_count(view_count_data, team)
+    assert result == nil
+  end
+
+  test "process_view_count does not send message of percentage increase is not reached", %{team: team, article: article} do
+    Repo.insert!(ViewCount.changeset(%ViewCount{}, %{article_id: article.id, count: 500}))
+    view_count_data = %{path: article.path, count: 20}
+    result = ViewCountHandler.process_view_count(view_count_data, team)
+    assert result == nil
+  end
+
+  test "process_view_count sends a message if the view count is a spike", %{team: team, article: article} do
+    Repo.insert!(ViewCount.changeset(%ViewCount{}, %{article_id: article.id, count: 5}))
+    view_count_data = %{path: article.path, count: 24}
+    result = ViewCountHandler.process_view_count(view_count_data, team)
+
+    # if we send a message EspiDni.SlackWeb.send_message will return a tuple
+    # for now just test that this is not nil, but I need to figure out the correct way 
+    # to test this
+    assert is_nil(result) == false
+  end
+end

--- a/web/models/view_count_handler.ex
+++ b/web/models/view_count_handler.ex
@@ -15,7 +15,6 @@ defmodule EspiDni.ViewCountHandler do
     if new_view_count do
       notify_if_count_spike(article)
     end
-
   end
 
   defp notify_if_count_spike(article) do
@@ -73,5 +72,4 @@ defmodule EspiDni.ViewCountHandler do
       limit: 2
     )
   end
-
 end

--- a/web/models/view_count_handler.ex
+++ b/web/models/view_count_handler.ex
@@ -1,0 +1,77 @@
+defmodule EspiDni.ViewCountHandler do
+
+  alias EspiDni.Repo
+  alias EspiDni.ViewCount
+  import EspiDni.Gettext
+  import Ecto.Query
+
+  @minimum_increase 10
+  @increase_threshold_percentage 25
+
+  def process_view_count(view_count_data, team) do
+    article = get_article(view_count_data.path, team)
+    new_view_count = create_view_count(article, view_count_data)
+
+    if new_view_count do
+      notify_if_count_spike(article)
+    end
+
+  end
+
+  defp notify_if_count_spike(article) do
+    latest_counts = last_two_counts(article)
+    if view_count_spike?(latest_counts) do
+      send_spike_message(
+        article,
+        latest_counts
+      )
+    end
+  end
+
+  def send_spike_message(article, latest_counts) do
+    message =  gettext("Message Spike", %{article_url: article.url, count: hd(latest_counts)})
+
+    case EspiDni.SlackWeb.send_message(article.user, message) do
+      %{"ok" => true } -> {:ok, article.user}
+      %{"ok" => false } -> {:error, article.user}
+    end
+  end
+
+  defp view_count_spike?([current_count | [previous_count]]) do
+    difference = current_count - previous_count
+    percentage_increase = (difference / previous_count * 100)
+
+    (difference >= @minimum_increase) && (percentage_increase >= @increase_threshold_percentage)
+  end
+
+  # return false if there's not a list with two entries
+  defp view_count_spike?(_), do: false
+
+  defp create_view_count(nil, _), do: :nil
+
+  defp create_view_count(article, view_count_data) do
+    ViewCount.changeset(%ViewCount{}, %{article_id: article.id, count: view_count_data.count})
+    |> Repo.insert!()
+  end
+
+  defp get_article(path, team) do
+    Repo.one(
+      from article in EspiDni.Article,
+      join: user in EspiDni.User, on: user.id == article.user_id,
+      where: user.team_id == ^team.id,
+      where: article.path == ^path,
+      preload: :user
+    )
+  end
+
+  defp last_two_counts(article) do
+    Repo.all(
+      from view_count in ViewCount,
+      select: view_count.count,
+      where: view_count.article_id == ^article.id,
+      order_by: [desc: view_count.id],
+      limit: 2
+    )
+  end
+
+end


### PR DESCRIPTION
Adds `EspiDni.ViewCountHandler` to handle incoming viewcount data. 
- Creates new viewcount entries
- Sends slack message to user if viewcounts have spiked
  - A spike is defined as an increase of at leat 10 views and an increase percentage of at least 25%
