### PR TITLE
Feature/refactor viewcount handling

### DIFF
--- a/lib/espi_dni/analytics_manager.ex
+++ b/lib/espi_dni/analytics_manager.ex
@@ -10,5 +10,8 @@ defmodule EspiDni.AnalyticsManager do
     for view_count_data <- results do
       EspiDni.ViewCountHandler.process_view_count(view_count_data, team)
     end
+
+    Logger.info "Notifying of any view_count spikes for team: #{team.id}"
+    EspiDni.SpikeNotifier.notify_recent_spikes(team)
   end
 end

--- a/lib/espi_dni/google_realtime_client.ex
+++ b/lib/espi_dni/google_realtime_client.ex
@@ -3,7 +3,9 @@ defmodule EspiDni.GoogleRealtimeClient do
   require Logger
 
   @metrics "rt:pageviews"
-  @dimensions "rt:pagePath"
+  @page_path "rt:pagePath"
+  @page_source "rt:source"
+  @dimensions "rt:pagePath, rt:source"
   @url "https://www.googleapis.com/analytics/v3/data/realtime"
 
   def get_pageviews(team) do
@@ -55,7 +57,8 @@ defmodule EspiDni.GoogleRealtimeClient do
 
   defp parse_viewcount(headers, row) do
     %{
-      path: get_data(headers, row, @dimensions),
+      path: get_data(headers, row, @page_path),
+      source: get_data(headers, row, @page_source),
       count: get_data(headers, row, @metrics)
     }
   end

--- a/lib/espi_dni/spike_notifier.ex
+++ b/lib/espi_dni/spike_notifier.ex
@@ -1,0 +1,79 @@
+defmodule EspiDni.SpikeNotifier do
+  require Logger
+  alias EspiDni.Repo
+  alias EspiDni.ViewCount
+  alias EspiDni.Article
+  import Ecto.Query
+
+  @minimum_increase 10
+  @increase_threshold_percentage 25
+
+  def notify_recent_spikes(team) do
+    for article <- recently_active_articles do
+      notify_if_count_spike(article, team)
+    end
+  end
+
+  defp recently_active_articles do
+    Repo.all(
+      from article in Article,
+      join: view_count in ViewCount, on: view_count.article_id == article.id,
+      where: view_count.inserted_at < ago(5, "minute"),
+      group_by: article.id,
+      preload: :user
+    )
+  end
+
+  def notify_if_count_spike(article, team) do
+    latest_counts = last_two_counts(article)
+    foo= view_count_spike?(latest_counts, team)
+
+    if view_count_spike?(latest_counts, team) do
+      send_spike_message(article, latest_counts)
+    end
+  end
+
+  defp last_two_counts(article) do
+    Repo.all(
+      from view_count in ViewCount,
+      select: sum(view_count.count),
+      where: view_count.article_id == ^article.id,
+      group_by: fragment("round(extract('epoch' from inserted_at) / 1800)"),
+      order_by: fragment("round(extract('epoch' from inserted_at) / 1800) desc"),
+      limit: 2
+    )
+  end
+
+  defp view_count_spike?([current_count | [previous_count]], team) do
+    difference              = current_count - previous_count
+    percentage_increase     = (difference / previous_count * 100)
+    min_difference          = team.min_view_count_increase || @minimum_increase
+    min_percentage_increase = team.view_count_threshold || @increase_threshold_percentage
+
+    (difference >= min_difference) && (percentage_increase >= min_percentage_increase)
+  end
+
+  # return false if there's not a list with two entries
+  defp view_count_spike?(_, _team), do: false
+
+  defp send_spike_message(article, latest_counts) do
+    message = spike_message(article, latest_counts)
+
+    case EspiDni.SlackWeb.send_message(article.user, message) do
+      %{"ok" => true } -> {:ok, article.user}
+      %{"ok" => false } -> {:error, article.user}
+    end
+  end
+
+  defp spike_message(%{url: url}, [current_count | [previous_count]]) do
+    string_number = :rand.uniform(6)
+    count = current_count - previous_count
+
+    Gettext.gettext(
+      EspiDni.Gettext,
+      "Message Spike #{string_number}",
+      article_url: url,
+      count: count
+    )
+  end
+end

--- a/lib/espi_dni/spike_notifier.ex
+++ b/lib/espi_dni/spike_notifier.ex
@@ -3,22 +3,25 @@ defmodule EspiDni.SpikeNotifier do
   alias EspiDni.Repo
   alias EspiDni.ViewCount
   alias EspiDni.Article
+  alias EspiDni.User
   import Ecto.Query
 
   @minimum_increase 10
   @increase_threshold_percentage 25
 
   def notify_recent_spikes(team) do
-    for article <- recently_active_articles do
+    for article <- recently_active_articles(team) do
       notify_if_count_spike(article, team)
     end
   end
 
-  defp recently_active_articles do
+  defp recently_active_articles(team) do
     Repo.all(
       from article in Article,
       join: view_count in ViewCount, on: view_count.article_id == article.id,
+      join: user in User, on: user.id == article.user_id,
       where: view_count.inserted_at < ago(5, "minute"),
+      where: user.team_id == ^team.id,
       group_by: article.id,
       preload: :user
     )
@@ -26,7 +29,6 @@ defmodule EspiDni.SpikeNotifier do
 
   def notify_if_count_spike(article, team) do
     latest_counts = last_two_counts(article)
-    foo= view_count_spike?(latest_counts, team)
 
     if view_count_spike?(latest_counts, team) do
       send_spike_message(article, latest_counts)

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,8 @@ defmodule EspiDni.Mixfile do
      {:gproc, "~> 0.6.1"},
      {:rollbax, "~> 0.7.0"},
      {:exq, git: "https://github.com/akira/exq.git"},
-     {:credo, "~> 0.4", only: [:dev, :test]}
+     {:credo, "~> 0.4", only: [:dev, :test]},
+     {:ex_machina, "~> 1.0", only: :test}
    ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,7 @@
   "db_connection": {:hex, :db_connection, "1.0.0-rc.5", "1d9ab6e01387bdf2de7a16c56866971f7c2f75aea7c69cae2a0346e4b537ae0d", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.2.0", "462960fd71af282e570f7b477f6be56bf8968e68277d4d0b641a635269bf4b0d", [:mix], []},
   "ecto": {:hex, :ecto, "2.0.5", "7f4c79ac41ffba1a4c032b69d7045489f0069c256de606523c65d9f8188e502d", [:mix], [{:db_connection, "~> 1.0-rc.4", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.1.2 or ~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.12.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
+  "ex_machina": {:hex, :ex_machina, "1.0.2", "1cc49e1a09e3f7ab2ecb630c17f14c2872dc4ec145d6d05a9c3621936a63e34f", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: true]}]},
   "exjsx": {:hex, :exjsx, "3.2.0", "7136cc739ace295fc74c378f33699e5145bead4fdc1b4799822d0287489136fb", [:mix], [{:jsx, "~> 2.6.2", [hex: :jsx, optional: false]}]},
   "exq": {:git, "https://github.com/akira/exq.git", "84e05ffac13b5cb1b7d04db0da9a0684602eb888", []},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},

--- a/priv/repo/migrations/20161025122548_add_source_to_view_counts.exs
+++ b/priv/repo/migrations/20161025122548_add_source_to_view_counts.exs
@@ -1,0 +1,9 @@
+defmodule EspiDni.Repo.Migrations.AddSourceToViewCounts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:view_counts) do
+      add :source, :string
+    end
+  end
+end

--- a/test/lib/spike_notifier_test.exs
+++ b/test/lib/spike_notifier_test.exs
@@ -1,0 +1,49 @@
+defmodule EspiDni.SpikeNotifierTest do
+  use ExUnit.Case
+  import EspiDni.Factory
+  alias EspiDni.SpikeNotifier
+  alias EspiDni.Team
+  alias EspiDni.Repo
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    team    = insert(:team)
+    user    = insert(:user, %{team: team})
+    article = insert(:article, %{user: user})
+
+    {:ok, team: team, article: article}
+  end
+
+  # if we send a message EspiDni.SlackWeb.send_message will return a tuple
+  # for now just test that this is not nil, but I need to figure out the correct way
+  # to test this
+
+  test "notify_if_count_spike does not send message of min view count increase is not reached", %{team: team, article: article} do
+    insert_previous_view_count(%{article_id: article.id, count: 5})
+    insert(:view_count, %{article_id: article.id, count: 5})
+    result = SpikeNotifier.notify_if_count_spike(article, team)
+    assert result == nil
+  end
+
+  test "notify_if_count_spike does not send message of percentage increase is not reached", %{team: team, article: article} do
+    insert_previous_view_count(%{article_id: article.id, count: 500})
+    insert(:view_count, %{article_id: article.id, count: 20})
+    result = SpikeNotifier.notify_if_count_spike(article, team)
+    assert result == nil
+  end
+
+  test "notify_if_count_spike sends a message if the view count is a spike", %{team: team, article: article} do
+    insert_previous_view_count(%{article_id: article.id, count: 5})
+    insert(:view_count, %{article_id: article.id, count: 24})
+    result = SpikeNotifier.notify_if_count_spike(article, team)
+    assert is_nil(result) == false
+  end
+
+  test "process_view_count users team preferences for min views if set", %{team: team, article: article} do
+    insert_previous_view_count(%{article_id: article.id, count: 10})
+    team = Repo.update!(Team.changeset(team, %{min_view_count_increase: 2, view_count_threshold: 20}))
+    insert(:view_count, %{article_id: article.id, count: 12})
+    result = SpikeNotifier.notify_if_count_spike(article, team)
+    assert is_nil(result) == false
+  end
+end

--- a/test/models/view_count_handler_test.exs
+++ b/test/models/view_count_handler_test.exs
@@ -2,7 +2,6 @@ defmodule EspiDni.ViewCountHandlerTest do
   use EspiDni.ModelCase
   alias EspiDni.ViewCountHandler
   alias EspiDni.ViewCount
-  alias EspiDni.Team
 
   setup do
     team = insert_team
@@ -13,51 +12,18 @@ defmodule EspiDni.ViewCountHandlerTest do
   end
 
   test "process_view_count creates a new viewcount for an existing article", %{team: team, article: article} do
-    view_count_data = %{path: article.path, count: 42}
+    view_count_data = %{path: article.path, count: 42, source: "google"}
     ViewCountHandler.process_view_count(view_count_data, team)
 
     view_count = Repo.one(from view_count in ViewCount, order_by: [desc: view_count.id], limit: 1)
     assert view_count.count == 42
     assert view_count.article_id == article.id
+    assert view_count.source == "google"
   end
 
   test "process_view_count does not create a record for an unknown path", %{team: team} do
     view_count_data = %{path: "/unknown_path", count: 42}
     ViewCountHandler.process_view_count(view_count_data, team)
     assert Repo.one(from view_count in ViewCount, select: count(view_count.id)) == 0
-  end
-
-  test "process_view_count does not send message of min view count increase is not reached", %{team: team, article: article} do
-    insert_previous_view_count(%{article_id: article.id, count: 5})
-    view_count_data = %{path: article.path, count: 14}
-    result = ViewCountHandler.process_view_count(view_count_data, team)
-    assert result == nil
-  end
-
-  test "process_view_count does not send message of percentage increase is not reached", %{team: team, article: article} do
-    insert_previous_view_count(%{article_id: article.id, count: 500})
-    view_count_data = %{path: article.path, count: 20}
-    result = ViewCountHandler.process_view_count(view_count_data, team)
-    assert result == nil
-  end
-
-  test "process_view_count sends a message if the view count is a spike", %{team: team, article: article} do
-    insert_previous_view_count(%{article_id: article.id, count: 5})
-    view_count_data = %{path: article.path, count: 24}
-    result = ViewCountHandler.process_view_count(view_count_data, team)
-
-    # if we send a message EspiDni.SlackWeb.send_message will return a tuple
-    # for now just test that this is not nil, but I need to figure out the correct way 
-    # to test this
-    assert is_nil(result) == false
-  end
-
-  test "process_view_count users team preferences for min views if set", %{team: team, article: article} do
-    insert_previous_view_count(%{article_id: article.id, count: 10})
-    team = Repo.update!(Team.changeset(team, %{min_view_count_increase: 2, view_count_threshold: 20}))
-    view_count_data = %{path: article.path, count: 12}
-    result = ViewCountHandler.process_view_count(view_count_data, team)
-
-    assert is_nil(result) == false
   end
 end

--- a/test/models/view_count_handler_test.exs
+++ b/test/models/view_count_handler_test.exs
@@ -28,21 +28,21 @@ defmodule EspiDni.ViewCountHandlerTest do
   end
 
   test "process_view_count does not send message of min view count increase is not reached", %{team: team, article: article} do
-    Repo.insert!(ViewCount.changeset(%ViewCount{}, %{article_id: article.id, count: 5}))
+    insert_previous_view_count(%{article_id: article.id, count: 5})
     view_count_data = %{path: article.path, count: 14}
     result = ViewCountHandler.process_view_count(view_count_data, team)
     assert result == nil
   end
 
   test "process_view_count does not send message of percentage increase is not reached", %{team: team, article: article} do
-    Repo.insert!(ViewCount.changeset(%ViewCount{}, %{article_id: article.id, count: 500}))
+    insert_previous_view_count(%{article_id: article.id, count: 500})
     view_count_data = %{path: article.path, count: 20}
     result = ViewCountHandler.process_view_count(view_count_data, team)
     assert result == nil
   end
 
   test "process_view_count sends a message if the view count is a spike", %{team: team, article: article} do
-    Repo.insert!(ViewCount.changeset(%ViewCount{}, %{article_id: article.id, count: 5}))
+    insert_previous_view_count(%{article_id: article.id, count: 5})
     view_count_data = %{path: article.path, count: 24}
     result = ViewCountHandler.process_view_count(view_count_data, team)
 
@@ -53,7 +53,7 @@ defmodule EspiDni.ViewCountHandlerTest do
   end
 
   test "process_view_count users team preferences for min views if set", %{team: team, article: article} do
-    Repo.insert!(ViewCount.changeset(%ViewCount{}, %{article_id: article.id, count: 10}))
+    insert_previous_view_count(%{article_id: article.id, count: 10})
     team = Repo.update!(Team.changeset(team, %{min_view_count_increase: 2, view_count_threshold: 20}))
     view_count_data = %{path: article.path, count: 12}
     result = ViewCountHandler.process_view_count(view_count_data, team)

--- a/test/models/view_count_test.exs
+++ b/test/models/view_count_test.exs
@@ -2,7 +2,7 @@ defmodule EspiDni.ViewCountTest do
   use EspiDni.ModelCase
   alias EspiDni.ViewCount
 
-  @valid_attrs %{count: 42, article_id: 1}
+  @valid_attrs %{count: 42, article_id: 1, source: "google"}
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,9 +1,8 @@
 defmodule EspiDni.Factory do
   use ExMachina.Ecto, repo: EspiDni.Repo
 
- def view_count_factory do
-    %EspiDni.ViewCount{
-      count: 5,
-    }
+  def view_count_factory do
+    %EspiDni.ViewCount{}
   end
+
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,0 +1,9 @@
+defmodule EspiDni.Factory do
+  use ExMachina.Ecto, repo: EspiDni.Repo
+
+ def view_count_factory do
+    %EspiDni.ViewCount{
+      count: 5,
+    }
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,8 +1,32 @@
 defmodule EspiDni.Factory do
   use ExMachina.Ecto, repo: EspiDni.Repo
 
+  def team_factory do
+    %EspiDni.Team {
+      slack_token: "supersecret",
+      name: "some team",
+      slack_id: sequence(:slack_id, &"team_token-#{&1}")
+    }
+  end
+
+  def user_factory do
+    %EspiDni.User{
+      name: "Some User",
+      username: sequence(:username, &"user-#{&1}"),
+      email: sequence(:email, &"email-#{&1}@example.com"),
+      slack_id: sequence(:slack_id, &"user_token-#{&1}")
+    }
+  end
+
   def view_count_factory do
     %EspiDni.ViewCount{}
   end
 
+  def insert_previous_view_count(attrs \\ %{}) do
+    half_hour_ago = Ecto.DateTime.cast!(Timex.shift(Timex.now, minutes: -30))
+
+    build(:view_count, attrs)
+    |> Map.merge(%{inserted_at: half_hour_ago, updated_at: half_hour_ago})
+    |> insert
+  end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -18,6 +18,13 @@ defmodule EspiDni.Factory do
     }
   end
 
+  def article_factory do
+    %EspiDni.Article{
+      url: sequence(:url, &"http://www.example.com/foobar-#{&1}"),
+      path: sequence(:path, &"foobar-#{&1}")
+    }
+  end
+
   def view_count_factory do
     %EspiDni.ViewCount{}
   end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,4 +1,5 @@
 defmodule EspiDni.TestHelpers do
+  import EspiDni.Factory
   alias EspiDni.Repo
 
   def insert_team(attrs \\ %{}) do
@@ -37,6 +38,14 @@ defmodule EspiDni.TestHelpers do
     user
     |> Ecto.build_assoc(:articles, article_attrs)
     |> Repo.insert!()
+  end
+
+  def insert_previous_view_count(attrs \\ %{}) do
+    half_hour_ago = Ecto.DateTime.cast!(Timex.shift(Timex.now, minutes: -30))
+
+    build(:view_count, attrs)
+    |> Map.merge(%{inserted_at: half_hour_ago, updated_at: half_hour_ago})
+    |> insert
   end
 
   def slack_token do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -40,14 +40,6 @@ defmodule EspiDni.TestHelpers do
     |> Repo.insert!()
   end
 
-  def insert_previous_view_count(attrs \\ %{}) do
-    half_hour_ago = Ecto.DateTime.cast!(Timex.shift(Timex.now, minutes: -30))
-
-    build(:view_count, attrs)
-    |> Map.merge(%{inserted_at: half_hour_ago, updated_at: half_hour_ago})
-    |> insert
-  end
-
   def slack_token do
     Application.get_env(:espi_dni, EspiDni.Plugs.RequireSlackToken)[:slack_token]
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
 ExUnit.start
 Ecto.Adapters.SQL.Sandbox.mode(EspiDni.Repo, :manual)
+{:ok, _} = Application.ensure_all_started(:ex_machina)

--- a/web/models/view_count.ex
+++ b/web/models/view_count.ex
@@ -3,13 +3,14 @@ defmodule EspiDni.ViewCount do
 
   schema "view_counts" do
     field :count, :integer
+    field :source, :string
     belongs_to :article, EspiDni.Article
 
     timestamps
   end
 
   @required_fields ~w(count article_id)
-  @optional_fields ~w()
+  @optional_fields ~w(source)
 
   @doc """
   Creates a changeset based on the `model` and `params`.

--- a/web/models/view_count_handler.ex
+++ b/web/models/view_count_handler.ex
@@ -70,9 +70,10 @@ defmodule EspiDni.ViewCountHandler do
   defp last_two_counts(article) do
     Repo.all(
       from view_count in ViewCount,
-      select: view_count.count,
+      select: sum(view_count.count),
       where: view_count.article_id == ^article.id,
-      order_by: [desc: view_count.id],
+      group_by: fragment("round(extract('epoch' from inserted_at) / 1800)"),
+      order_by: fragment("round(extract('epoch' from inserted_at) / 1800) desc"),
       limit: 2
     )
   end


### PR DESCRIPTION
We want to start tracking the source of view counts. To make this cleaner we need to decouple the view_count handling from spike notifications.

This PR:
- creates a separate module handle spike notifications
- integrates [ex_machina](https://github.com/thoughtbot/ex_machina) factory library to make test setup easier
- adds source column to view counts and pulls source in from analytic data
