### PR TITLE
Feature/source notifications

### DIFF
--- a/lib/espi_dni/analytics_manager.ex
+++ b/lib/espi_dni/analytics_manager.ex
@@ -1,19 +1,24 @@
 defmodule EspiDni.AnalyticsManager do
 
   require Logger
-  alias EspiDni.GoogleAnalyticsClient
+  alias EspiDni.{
+    GoogleRealtimeClient,
+    ViewCountHandler,
+    Article,
+    ArticleViewCountNotifier
+  }
 
   def retrieve_anlaytics(team) do
     Logger.info "Retrieving analytics for team: #{team.id}"
-    results = EspiDni.GoogleRealtimeClient.get_pageviews(team)
+    results = GoogleRealtimeClient.get_pageviews(team)
 
     for view_count_data <- results do
-      EspiDni.ViewCountHandler.process_view_count(view_count_data, team)
+      ViewCountHandler.process_view_count(view_count_data, team)
     end
 
-    active_articles = Article.recently_active(team)
-
-    Logger.info "Notifying of any view_count spikes for team: #{team.id}"
-    EspiDni.ArticleViewCountNotifier.notify_recent_spikes(team, active_articles)
+    Logger.info "Checking view_count spikes for team: #{team.id}"
+    for article <- Article.recently_active(team) do
+      ArticleViewCountNotifier.notify_if_spike(article, team)
+    end
   end
 end

--- a/lib/espi_dni/analytics_manager.ex
+++ b/lib/espi_dni/analytics_manager.ex
@@ -14,6 +14,6 @@ defmodule EspiDni.AnalyticsManager do
     active_articles = Article.recently_active(team)
 
     Logger.info "Notifying of any view_count spikes for team: #{team.id}"
-    EspiDni.SpikeNotifier.notify_recent_spikes(team, active_articles)
+    EspiDni.ArticleViewCountNotifier.notify_recent_spikes(team, active_articles)
   end
 end

--- a/lib/espi_dni/analytics_manager.ex
+++ b/lib/espi_dni/analytics_manager.ex
@@ -11,7 +11,9 @@ defmodule EspiDni.AnalyticsManager do
       EspiDni.ViewCountHandler.process_view_count(view_count_data, team)
     end
 
+    active_articles = Article.recently_active(team)
+
     Logger.info "Notifying of any view_count spikes for team: #{team.id}"
-    EspiDni.SpikeNotifier.notify_recent_spikes(team)
+    EspiDni.SpikeNotifier.notify_recent_spikes(team, active_articles)
   end
 end

--- a/lib/espi_dni/article_slack_messenger.ex
+++ b/lib/espi_dni/article_slack_messenger.ex
@@ -5,8 +5,8 @@ defmodule EspiDni.ArticleSlackMessenger do
     Repo
   }
 
-  def send_view_spike_message(article, latest_counts) do
-    message = view_spike_message(article, latest_counts)
+  def send_view_spike_message(article, count_increase) do
+    message = view_spike_message(article, count_increase)
     user    = article_user(article)
 
     case SlackWeb.send_message(user, message) do
@@ -15,15 +15,14 @@ defmodule EspiDni.ArticleSlackMessenger do
     end
   end
 
-  defp view_spike_message(%{url: url}, [current_count | [previous_count]]) do
+  defp view_spike_message(%{url: url}, count_increase) do
     string_number = :rand.uniform(6)
-    count = current_count - previous_count
 
     Gettext.gettext(
       EspiDni.Gettext,
       "Message Spike #{string_number}",
       article_url: url,
-      count: count
+      count: count_increase
     )
   end
 

--- a/lib/espi_dni/article_slack_messenger.ex
+++ b/lib/espi_dni/article_slack_messenger.ex
@@ -9,20 +9,14 @@ defmodule EspiDni.ArticleSlackMessenger do
     message = view_spike_message(article, count_increase)
     user    = article_user(article)
 
-    case SlackWeb.send_message(user, message) do
-      %{"ok" => true } -> {:ok, user}
-      %{"ok" => false } -> {:error, user}
-    end
+    send_message(user, message)
   end
 
   def send_source_spike_message(article, source) do
     message = "Your article is seeing an increase in traffic from #{source.source}"
     user    = article_user(article)
 
-    case SlackWeb.send_message(user, message) do
-      %{"ok" => true } -> {:ok, user}
-      %{"ok" => false } -> {:error, user}
-    end
+    send_message(user, message)
   end
 
   defp view_spike_message(%{url: url}, count_increase) do
@@ -36,8 +30,19 @@ defmodule EspiDni.ArticleSlackMessenger do
     )
   end
 
+  defp source_spike_message(%{url: url}, %{source: source}) do
+    "Your article is seeing an increase in traffic from #{source.source}"
+  end
+
   defp article_user(article) do
     Repo.preload(article, :user).user
+  end
+
+  defp send_message(user, message) do
+    case SlackWeb.send_message(user, message) do
+      %{"ok" => true } -> {:ok, user}
+      %{"ok" => false } -> {:error, user}
+    end
   end
 
 end

--- a/lib/espi_dni/article_slack_messenger.ex
+++ b/lib/espi_dni/article_slack_messenger.ex
@@ -4,6 +4,7 @@ defmodule EspiDni.ArticleSlackMessenger do
     SlackWeb,
     Repo
   }
+  import EspiDni.Gettext
 
   def send_view_spike_message(article, count_increase) do
     message = view_spike_message(article, count_increase)
@@ -13,7 +14,7 @@ defmodule EspiDni.ArticleSlackMessenger do
   end
 
   def send_source_spike_message(article, source) do
-    message = "Your article is seeing an increase in traffic from #{source.source}"
+    message = source_spike_message(article, source)
     user    = article_user(article)
 
     send_message(user, message)
@@ -30,8 +31,31 @@ defmodule EspiDni.ArticleSlackMessenger do
     )
   end
 
+  defp source_spike_message(%{url: url}, %{source: "Twitter"}) do
+    gettext(
+      "Twitter Source",
+      article_url: url,
+      article_search_url: url_without_protocol(url)
+    )
+  end
+
+  defp source_spike_message(%{url: url}, %{source: "Facebook"}) do
+    gettext(
+      "Twitter Source",
+      article_url: url,
+      article_search_url: url_without_protocol(url)
+    )
+  end
+
   defp source_spike_message(%{url: url}, %{source: source}) do
-    "Your article is seeing an increase in traffic from #{source.source}"
+    string_number = :rand.uniform(2)
+
+    Gettext.gettext(
+      EspiDni.Gettext,
+      "Generic Source Spike #{string_number}",
+      article_url: url,
+      source_name: source
+    )
   end
 
   defp article_user(article) do
@@ -43,6 +67,11 @@ defmodule EspiDni.ArticleSlackMessenger do
       %{"ok" => true } -> {:ok, user}
       %{"ok" => false } -> {:error, user}
     end
+  end
+
+  defp url_without_protocol(url) do
+    parsed_url = URI.parse(url)
+    parsed_url.host <> parsed_url.path
   end
 
 end

--- a/lib/espi_dni/article_slack_messenger.ex
+++ b/lib/espi_dni/article_slack_messenger.ex
@@ -1,0 +1,34 @@
+defmodule EspiDni.ArticleSlackMessenger do
+
+  alias EspiDni.{
+    SlackWeb,
+    Repo
+  }
+
+  def send_view_spike_message(article, latest_counts) do
+    message = view_spike_message(article, latest_counts)
+    user    = article_user(article)
+
+    case SlackWeb.send_message(user, message) do
+      %{"ok" => true } -> {:ok, user}
+      %{"ok" => false } -> {:error, user}
+    end
+  end
+
+  defp view_spike_message(%{url: url}, [current_count | [previous_count]]) do
+    string_number = :rand.uniform(6)
+    count = current_count - previous_count
+
+    Gettext.gettext(
+      EspiDni.Gettext,
+      "Message Spike #{string_number}",
+      article_url: url,
+      count: count
+    )
+  end
+
+  defp article_user(article) do
+    Repo.preload(article, :user).user
+  end
+
+end

--- a/lib/espi_dni/article_slack_messenger.ex
+++ b/lib/espi_dni/article_slack_messenger.ex
@@ -15,6 +15,16 @@ defmodule EspiDni.ArticleSlackMessenger do
     end
   end
 
+  def send_source_spike_message(article, source) do
+    message = "Your article is seeing an increase in traffic from #{source.source}"
+    user    = article_user(article)
+
+    case SlackWeb.send_message(user, message) do
+      %{"ok" => true } -> {:ok, user}
+      %{"ok" => false } -> {:error, user}
+    end
+  end
+
   defp view_spike_message(%{url: url}, count_increase) do
     string_number = :rand.uniform(6)
 

--- a/lib/espi_dni/article_view_count_notifier.ex
+++ b/lib/espi_dni/article_view_count_notifier.ex
@@ -1,6 +1,5 @@
 defmodule EspiDni.ArticleViewCountNotifier do
 
-  require Logger
   import Ecto.Query
   alias EspiDni.{
     Repo,
@@ -8,6 +7,7 @@ defmodule EspiDni.ArticleViewCountNotifier do
     Article,
     ArticleSlackMessenger
   }
+  require Logger
 
   @minimum_increase 10
   @increase_threshold_percentage 25

--- a/lib/espi_dni/article_view_count_notifier.ex
+++ b/lib/espi_dni/article_view_count_notifier.ex
@@ -16,7 +16,7 @@ defmodule EspiDni.ArticleViewCountNotifier do
     latest_counts = last_two_counts(article)
 
     if view_count_spike?(latest_counts, team) do
-      ArticleSlackMessenger.send_view_spike_message(article, latest_counts)
+      ArticleSlackMessenger.send_view_spike_message(article, count_increase(latest_counts))
     end
   end
 
@@ -32,8 +32,8 @@ defmodule EspiDni.ArticleViewCountNotifier do
     )
   end
 
-  defp view_count_spike?([current_count | [previous_count]], team) do
-    difference              = current_count - previous_count
+  defp view_count_spike?([current_count, previous_count], team) do
+    difference              = count_increase([current_count, previous_count])
     percentage_increase     = (difference / previous_count * 100)
     min_difference          = team.min_view_count_increase || @minimum_increase
     min_percentage_increase = team.view_count_threshold || @increase_threshold_percentage
@@ -43,5 +43,9 @@ defmodule EspiDni.ArticleViewCountNotifier do
 
   # return false if there's not a list with two entries
   defp view_count_spike?(_, _team), do: false
+
+  defp count_increase([current_count, previous_count]) do
+    current_count - previous_count
+  end
 
 end

--- a/lib/espi_dni/article_view_count_notifier.ex
+++ b/lib/espi_dni/article_view_count_notifier.ex
@@ -8,12 +8,6 @@ defmodule EspiDni.ArticleViewCountNotifier do
   @minimum_increase 10
   @increase_threshold_percentage 25
 
-  def notify_recent_spikes(team, active_articles) do
-    for article <- active_articles do
-      notify_if_count_spike(article, team)
-    end
-  end
-
   def notify_if_spike(article, team) do
     latest_counts = last_two_counts(article)
 

--- a/lib/espi_dni/article_view_count_notifier.ex
+++ b/lib/espi_dni/article_view_count_notifier.ex
@@ -1,9 +1,13 @@
 defmodule EspiDni.ArticleViewCountNotifier do
+
   require Logger
-  alias EspiDni.Repo
-  alias EspiDni.ViewCount
-  alias EspiDni.Article
   import Ecto.Query
+  alias EspiDni.{
+    Repo,
+    ViewCount,
+    Article,
+    ArticleSlackMessenger
+  }
 
   @minimum_increase 10
   @increase_threshold_percentage 25
@@ -12,7 +16,7 @@ defmodule EspiDni.ArticleViewCountNotifier do
     latest_counts = last_two_counts(article)
 
     if view_count_spike?(latest_counts, team) do
-      send_spike_message(article, latest_counts)
+      ArticleSlackMessenger.send_view_spike_message(article, latest_counts)
     end
   end
 
@@ -40,24 +44,4 @@ defmodule EspiDni.ArticleViewCountNotifier do
   # return false if there's not a list with two entries
   defp view_count_spike?(_, _team), do: false
 
-  defp send_spike_message(article, latest_counts) do
-    message = spike_message(article, latest_counts)
-
-    case EspiDni.SlackWeb.send_message(article.user, message) do
-      %{"ok" => true } -> {:ok, article.user}
-      %{"ok" => false } -> {:error, article.user}
-    end
-  end
-
-  defp spike_message(%{url: url}, [current_count | [previous_count]]) do
-    string_number = :rand.uniform(6)
-    count = current_count - previous_count
-
-    Gettext.gettext(
-      EspiDni.Gettext,
-      "Message Spike #{string_number}",
-      article_url: url,
-      count: count
-    )
-  end
 end

--- a/lib/espi_dni/article_view_count_notifier.ex
+++ b/lib/espi_dni/article_view_count_notifier.ex
@@ -1,4 +1,4 @@
-defmodule EspiDni.SpikeNotifier do
+defmodule EspiDni.ArticleViewCountNotifier do
   require Logger
   alias EspiDni.Repo
   alias EspiDni.ViewCount
@@ -14,7 +14,7 @@ defmodule EspiDni.SpikeNotifier do
     end
   end
 
-  def notify_if_count_spike(article, team) do
+  def notify_if_spike(article, team) do
     latest_counts = last_two_counts(article)
 
     if view_count_spike?(latest_counts, team) do

--- a/lib/espi_dni/source_notifier.ex
+++ b/lib/espi_dni/source_notifier.ex
@@ -1,0 +1,58 @@
+defmodule EspiDni.SpikeNotifier do
+  require Logger
+  alias EspiDni.Repo
+  alias EspiDni.ViewCount
+  alias EspiDni.Article
+  import Ecto.Query
+
+  @minimum_increase 2
+  @increase_threshold_percentage 25
+
+  def notify_if_source_spike(article, team) do
+    highest_sources = highest_sources(article)
+
+    if source_spike?(highest_sources, team) do
+      send_source_message(article, hd(highest_sources))
+    end
+  end
+
+  def source_spike?([highest_source, runner_up_source | _rest ], team) do
+    difference              = highest_source.count - runner_up_source.count
+    percentage_increase     = (highest_source.count / runner_up_source.count * 100)
+    min_difference          = @minimum_increase
+    min_percentage_increase = @increase_threshold_percentage
+
+    (difference >= min_difference) && (percentage_increase >= min_percentage_increase)
+  end
+
+  # return false if there's not a list with two entries
+  def source_spike?(_, team) do
+    Logger.info("No enough view counts returned for source notification check")
+    false
+  end
+
+  defp highest_sources(article) do
+    Repo.all(
+      from view_count in ViewCount,
+      select: %{
+        count: sum(view_count.count),
+        source: view_count.source
+      },
+      where: view_count.article_id == ^article.id,
+      where: not is_nil(view_count.source),
+      where: view_count.source != "(direct)",
+      group_by: view_count.source,
+      order_by: [desc: sum(view_count.count)], 
+      limit: 2
+    )
+  end
+
+  defp send_source_message(article, source) do
+    message = "Your article is seeing an increase in traffic to #{source.source}"
+
+    case EspiDni.SlackWeb.send_message(article.user, message) do
+      %{"ok" => true } -> {:ok, article.user}
+      %{"ok" => false } -> {:error, article.user}
+    end
+  end
+end

--- a/lib/espi_dni/spike_notifier.ex
+++ b/lib/espi_dni/spike_notifier.ex
@@ -27,6 +27,7 @@ defmodule EspiDni.SpikeNotifier do
       from view_count in ViewCount,
       select: sum(view_count.count),
       where: view_count.article_id == ^article.id,
+      where: view_count.inserted_at > ago(2, "hour"),
       group_by: fragment("round(extract('epoch' from inserted_at) / 1800)"),
       order_by: fragment("round(extract('epoch' from inserted_at) / 1800) desc"),
       limit: 2

--- a/lib/espi_dni/spike_notifier.ex
+++ b/lib/espi_dni/spike_notifier.ex
@@ -3,28 +3,15 @@ defmodule EspiDni.SpikeNotifier do
   alias EspiDni.Repo
   alias EspiDni.ViewCount
   alias EspiDni.Article
-  alias EspiDni.User
   import Ecto.Query
 
   @minimum_increase 10
   @increase_threshold_percentage 25
 
-  def notify_recent_spikes(team) do
-    for article <- recently_active_articles(team) do
+  def notify_recent_spikes(team, active_articles) do
+    for article <- active_articles do
       notify_if_count_spike(article, team)
     end
-  end
-
-  defp recently_active_articles(team) do
-    Repo.all(
-      from article in Article,
-      join: view_count in ViewCount, on: view_count.article_id == article.id,
-      join: user in User, on: user.id == article.user_id,
-      where: view_count.inserted_at < ago(5, "minute"),
-      where: user.team_id == ^team.id,
-      group_by: article.id,
-      preload: :user
-    )
   end
 
   def notify_if_count_spike(article, team) do

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -49,6 +49,18 @@ msgstr ""
 msgid "Message Spike 6"
 msgstr ""
 
+msgid "Generic Source Spike 1"
+msgstr ""
+
+msgid "Generic Source Spike 2"
+msgstr ""
+
+msgid "Twitter Source"
+msgstr ""
+
+msgid "Facebook Source"
+msgstr ""
+
 msgid "Article Confirm Prompt"
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -46,6 +46,18 @@ msgstr "Traffic to `%{article_url}` was great, but now it’s really heating up,
 msgid "Message Spike 6"
 msgstr "There’s a traffic spike on `%{article_url}`, with an increase of %{count} more page views — put yourself in your readers’ shoes and deliver the story to the platform where they really want to read it. :love_letter: (i.e FB Groups, Bulletin Boards or Reddit)"
 
+msgid "Generic Source Spike 1"
+msgstr "Hey, it seems like your article `%{article_url}` suddenly got a lot of traffic coming from `%{source_name}`! Talk to your audience development colleague to find ideas how you could build on that."
+
+msgid "Generic Source Spike 2"
+msgstr "Great! Your article `%{article_url}` is receiving a lot of visitors from`%{source_name}. Maybe you can replicate that success tomorrow at the same time?"
+
+msgid "Twitter Source"
+msgstr "Psssst! Seems like the elite crowd on Twitter just fell in love with `%{article_url}`! Get on twitter and join the conversation `https://twitter.com/search?f=tweets&q=%{article_search_url}` — authors engaging in social conversations on their article increases the readership."
+
+msgid "Facebook Source"
+msgstr "Psssst! Seems like the Facebook audience started talking about your `%{article_url}` right now! Get on Facebook and be part of the conversation `https://www.facebook.com/search/top/?q=%{article_search_url}`. Maybe there is a new perspective or story angle to your piece which would spin your story further or help you with a follow-up story."
+
 msgid "Setup Complete"
 msgstr "Great, thanks for completing the setup!\n\n"
   "Use the `/add` command to add a new article url."

--- a/test/lib/article_view_count_notifier_test.exs
+++ b/test/lib/article_view_count_notifier_test.exs
@@ -1,7 +1,7 @@
-defmodule EspiDni.SpikeNotifierTest do
+defmodule EspiDni.ArticleViewCountNotifierTest do
   use ExUnit.Case
   import EspiDni.Factory
-  alias EspiDni.SpikeNotifier
+  alias EspiDni.ArticleViewCountNotifier, as: Subject
   alias EspiDni.Team
   alias EspiDni.Repo
 
@@ -18,24 +18,24 @@ defmodule EspiDni.SpikeNotifierTest do
   # for now just test that this is not nil, but I need to figure out the correct way
   # to test this
 
-  test "notify_if_count_spike does not send message of min view count increase is not reached", %{team: team, article: article} do
+  test "notify_if_spike does not send message of min view count increase is not reached", %{team: team, article: article} do
     insert_previous_view_count(%{article_id: article.id, count: 5})
     insert(:view_count, %{article_id: article.id, count: 5})
-    result = SpikeNotifier.notify_if_count_spike(article, team)
+    result = Subject.notify_if_spike(article, team)
     assert result == nil
   end
 
-  test "notify_if_count_spike does not send message of percentage increase is not reached", %{team: team, article: article} do
+  test "notify_if_spike does not send message of percentage increase is not reached", %{team: team, article: article} do
     insert_previous_view_count(%{article_id: article.id, count: 500})
     insert(:view_count, %{article_id: article.id, count: 20})
-    result = SpikeNotifier.notify_if_count_spike(article, team)
+    result = Subject.notify_if_spike(article, team)
     assert result == nil
   end
 
-  test "notify_if_count_spike sends a message if the view count is a spike", %{team: team, article: article} do
+  test "notify_if_spike sends a message if the view count is a spike", %{team: team, article: article} do
     insert_previous_view_count(%{article_id: article.id, count: 5})
     insert(:view_count, %{article_id: article.id, count: 24})
-    result = SpikeNotifier.notify_if_count_spike(article, team)
+    result = Subject.notify_if_spike(article, team)
     assert is_nil(result) == false
   end
 
@@ -43,7 +43,7 @@ defmodule EspiDni.SpikeNotifierTest do
     insert_previous_view_count(%{article_id: article.id, count: 10})
     team = Repo.update!(Team.changeset(team, %{min_view_count_increase: 2, view_count_threshold: 20}))
     insert(:view_count, %{article_id: article.id, count: 12})
-    result = SpikeNotifier.notify_if_count_spike(article, team)
+    result = Subject.notify_if_spike(article, team)
     assert is_nil(result) == false
   end
 end

--- a/test/lib/article_view_source_notifier_test.exs
+++ b/test/lib/article_view_source_notifier_test.exs
@@ -1,0 +1,42 @@
+defmodule EspiDni.ArticleViewSourceNotifierTest do
+  use ExUnit.Case
+  alias EspiDni.ArticleViewSourceNotifier, as: Subject
+  alias EspiDni.Team
+  alias EspiDni.Repo
+  import EspiDni.Factory
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    team    = insert(:team)
+    user    = insert(:user, %{team: team})
+    article = insert(:article, %{user: user})
+
+    {:ok, team: team, article: article}
+  end
+
+  # if we send a message EspiDni.SlackWeb.send_message will return a tuple
+  # for now just test that this is not nil, but I need to figure out the correct way
+  # to test this
+
+  test "notify_if_spike does not send a message if source minimum increase is not reached", %{team: team, article: article} do
+    insert(:view_count, %{article_id: article.id, count: 2, source: "foo"})
+    insert(:view_count, %{article_id: article.id, count: 5, source: "baz"})
+    result = Subject.notify_if_spike(article, team)
+    assert result == nil
+  end
+
+  test "notify_if_spike does not send message of percentage increase is not reached", %{team: team, article: article} do
+    insert(:view_count, %{article_id: article.id, count: 500, source: "foo"})
+    insert(:view_count, %{article_id: article.id, count: 550, source: "baz"})
+    result = Subject.notify_if_spike(article, team)
+    assert result == nil
+  end
+
+  test "notify_if_spike sends a message if the view source increase is a spike", %{team: team, article: article} do
+    insert(:view_count, %{article_id: article.id, count: 2, source: "foo"})
+    insert(:view_count, %{article_id: article.id, count: 24, source: "baz"})
+    result = Subject.notify_if_spike(article, team)
+    assert is_nil(result) == false
+  end
+
+end


### PR DESCRIPTION
Adding another notification trigger to send a message to a user if the view count source of an article is significantly higher than other sources

* Refactor existing view count spike notification logic for better reuse
* Adds module to calculate source spikes

ping @edenspiekermann/backend 