### PR TITLE
Feature/allow multiple users

### DIFF
--- a/priv/repo/migrations/20161108170722_change_users_all_null_email.exs
+++ b/priv/repo/migrations/20161108170722_change_users_all_null_email.exs
@@ -1,0 +1,9 @@
+defmodule EspiDni.Repo.Migrations.ChangeUsersAllNullEmail do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      modify :email, :string, null: true
+    end
+  end
+end

--- a/test/controllers/slack_article_controller_test.exs
+++ b/test/controllers/slack_article_controller_test.exs
@@ -1,9 +1,11 @@
 defmodule EspiDni.SlackArticleControllerTest do
+  import EspiDni.Factory
   use EspiDni.ConnCase
 
   setup do
-    user = insert_team |> insert_user
-    {:ok, conn: build_conn, user: user}
+    team = insert(:team)
+    user = insert(:user, %{team: team})
+    {:ok, conn: build_conn, user: user, team: team}
   end
 
   test "returns a 401 for an invalid token", %{conn: conn} do
@@ -22,15 +24,15 @@ defmodule EspiDni.SlackArticleControllerTest do
     assert conn.resp_body =~ "Unknown User"
   end
 
-  test "returns a validation message for an invalid url", %{conn: conn, user: user} do
-    params = %{command: "/add", token: slack_token, user_id: user.slack_id, text: "invalid_url"}
+  test "returns a validation message for an invalid url", %{conn: conn, user: user, team: team} do
+    params = %{command: "/add", token: slack_token, user_id: user.slack_id, team_id: team.slack_id, text: "invalid_url"}
     conn = post conn, slack_article_path(conn, :new), params
 
     assert text_response(conn, 200) =~ "invalid_url is not a valid URL"
   end
 
-  test "returns an article confirmation response", %{conn: conn, user: user} do
-    params = %{command: "/add", token: slack_token, user_id: user.slack_id, text: "http://example.com" }
+  test "returns an article confirmation response", %{conn: conn, user: user, team: team} do
+    params = %{command: "/add", token: slack_token, user_id: user.slack_id, team_id: team.slack_id, text: "http://example.com" }
     conn = post conn, slack_article_path(conn, :new), params
 
     body = json_response(conn, 200)

--- a/test/plugs/set_slack_user_test.exs
+++ b/test/plugs/set_slack_user_test.exs
@@ -5,8 +5,10 @@ defmodule EspiDni.Plugs.SetSlackUserTest do
   @opts EspiDni.Plugs.SetSlackUser.init(repo: EspiDni.Repo)
 
   setup do
-    user = insert_team |> insert_user
-    {:ok, user: user}
+    team = insert_team
+    user = insert_user(team)
+
+    {:ok, user: user, team: team}
   end
 
   test "returns 401 for a missing user_id" do
@@ -18,13 +20,25 @@ defmodule EspiDni.Plugs.SetSlackUserTest do
     assert conn.status == 404
   end
 
-  test "returns 404 for an invalid user id param" do
+  test "returns 404 for an invalid user id and team_id" do
     conn =
-      build_conn(:get, "/", %{user_id: "invalid"})
+      build_conn(:get, "/", %{user_id: "invalid", team_id: "invalid"})
       |> EspiDni.Plugs.SetSlackUser.call(@opts)
 
     assert conn.halted
     assert conn.status == 404
+  end
+
+  test "creates a new user and passes through for valid team_id and new user_id", %{team: team} do
+    conn =
+      build_conn(:get, "/", %{user_id: "new_slack_id", user_name: "newuser", team_id: team.slack_id})
+      |> EspiDni.Plugs.SetSlackUser.call(@opts)
+
+    new_user = Repo.get_by(EspiDni.User, slack_id: "new_slack_id")
+    assert conn.assigns.current_user == new_user
+    assert new_user.username == "newuser"
+    assert new_user.team_id == team.id
+    refute conn.halted
   end
 
   test "returns 404 for an invalid user id in the payload" do
@@ -37,19 +51,19 @@ defmodule EspiDni.Plugs.SetSlackUserTest do
     assert conn.status == 404
   end
 
-  test "request passes through when the correct user_id parm is present", %{user: user}  do
+  test "request passes through when the correct user_id param is present", %{user: user, team: team}  do
     conn =
-      build_conn(:get, "/", %{user_id: user.slack_id})
+      build_conn(:get, "/", %{user_id: user.slack_id, team_id: team.slack_id})
       |> EspiDni.Plugs.SetSlackUser.call(@opts)
 
     assert conn.assigns.current_user == user
     refute conn.halted
   end
 
-  test "request passes through when the correct user_id is in the payload", %{user: user}  do
+  test "request passes through when the correct user_id is in the payload", %{user: user, team: team}  do
     conn =
       build_conn(:get, "/", %{})
-      |> assign(:payload, %{"user" => %{"id" => user.slack_id}})
+      |> assign(:payload, %{"user" => %{"id" => user.slack_id}, "team" => %{"id" => team.slack_id}})
       |> EspiDni.Plugs.SetSlackUser.call(@opts)
 
     assert conn.assigns.current_user == user

--- a/web/plugs/set_slack_user.ex
+++ b/web/plugs/set_slack_user.ex
@@ -1,22 +1,48 @@
 defmodule EspiDni.Plugs.SetSlackUser do
 
   import Plug.Conn
+  alias EspiDni.User
+  alias EspiDni.Team
 
   def init(opts) do
     Keyword.fetch!(opts, :repo)
   end
 
   def call(conn, repo) do
-    case repo.get_by(EspiDni.User, slack_id: user_id(conn)) do
+    case team(conn, repo) do
       nil ->
         conn |> send_resp(404, "Unknown User") |> halt
-      user ->
+      team ->
+        user = get_or_create_user(conn, team, repo)
         assign(conn, :current_user, user)
     end
   end
 
   defp user_id(conn) do
     conn.params["user_id"] || get_in(conn.assigns, [:payload, "user", "id"]) || ""
+  end
+
+  defp team_id(conn) do
+    conn.params["team_id"] || get_in(conn.assigns, [:payload, "team", "id"]) || ""
+  end
+
+  defp team(conn, repo) do
+    repo.get_by(Team, slack_id: team_id(conn))
+  end
+
+  defp get_or_create_user(conn, team, repo) do
+    case repo.get_by(User, slack_id: user_id(conn), team_id: team.id) do
+      nil -> create_user(conn, team, repo)
+      user -> user
+    end
+  end
+
+  defp create_user(conn, team, repo) do
+    repo.insert!(build_user(conn.params, team))
+  end
+
+  defp build_user(%{"user_name" => username, "user_id" => slack_id}, team) do
+    %User{username: username, slack_id: slack_id, team_id: team.id}
   end
 
 end


### PR DESCRIPTION
Currently we're returning a 404 if a an unknown users creates an article with a `/add` slash command. Instead, if the user is part of  a valid team, we should create the user and add the article.
