### PR TITLE
Feature/change ga property endpoint

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -14,7 +14,8 @@ config :espi_dni, EspiDni.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: "espi_dni_test",
   hostname: "localhost",
-  pool: Ecto.Adapters.SQL.Sandbox
+  pool: Ecto.Adapters.SQL.Sandbox,
+  ownership_timeout: 50_0000
 
 config :rollbax,
   access_token: "placeholder",

--- a/lib/espi_dni/google_analytics_client.ex
+++ b/lib/espi_dni/google_analytics_client.ex
@@ -5,7 +5,7 @@ defmodule EspiDni.GoogleAnalyticsClient do
 
   @base_url "https://www.googleapis.com"
   @token_refresh_path "/oauth2/v4/token"
-  @properties_path "/analytics/v3/management/accounts/~all/webproperties"
+  @properties_path "/analytics/v3/management/accounts/~all/webproperties/~all/profiles"
   @client_id Application.get_env(:ueberauth, Ueberauth.Strategy.Google.OAuth)[:client_id]
   @client_secret Application.get_env(:ueberauth, Ueberauth.Strategy.Google.OAuth)[:client_secret]
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
 ExUnit.start
 Ecto.Adapters.SQL.Sandbox.mode(EspiDni.Repo, :manual)
 {:ok, _} = Application.ensure_all_started(:ex_machina)
+ExUnit.configure(timeout: :infinity)

--- a/web/models/google_web_property.ex
+++ b/web/models/google_web_property.ex
@@ -1,4 +1,4 @@
 defmodule EspiDni.GoogleWebProperty do
   @derive [Poison.Encoder]
-  defstruct [:defaultProfileId, :name]
+  defstruct [:id, :name, :websiteUrl]
 end

--- a/web/views/setup_view.ex
+++ b/web/views/setup_view.ex
@@ -3,13 +3,19 @@ defmodule EspiDni.SetupView do
 
   alias EspiDni.Team
   alias EspiDni.GoogleAnalyticsClient
+  alias EspiDni.GoogleWebProperty
 
   def web_properties(%Team{} = team) do
-    GoogleAnalyticsClient.get_properties(team)
-    |> Enum.map(&{&1.name, &1.defaultProfileId})
+    team
+    |> GoogleAnalyticsClient.get_properties
+    |> Enum.map(&select_options(&1))
   end
 
   def team_changeset(%Team{} = team) do
     EspiDni.Team.changeset(team, %{})
+  end
+
+  defp select_options(%GoogleWebProperty{} = property) do
+    {"[#{property.websiteUrl}] - #{property.name}", property.id}
   end
 end


### PR DESCRIPTION
If a Google Analytics account does not have a default web property set, then the existing call to retrieve web properties will have no defaultProfileId. This updates API call to use a different endpoint that returns all the account's default profile ids, not relying on `defaultProfileId`