### PR TITLE
Don't throw an error if empty GA resultset returned

### DIFF
--- a/lib/espi_dni/google_realtime_client.ex
+++ b/lib/espi_dni/google_realtime_client.ex
@@ -49,6 +49,9 @@ defmodule EspiDni.GoogleRealtimeClient do
         Enum.map(rows, fn(row) ->
           parse_viewcount(headers, row)
         end)
+      %{"columnHeaders" => headers} ->
+        Logger.info "No view count data found."
+        []
       _ ->
         Logger.error "Pageview response in unexpected format: #{inspect response}"
         []


### PR DESCRIPTION
If the GA call returns successful with no results we should just return and empty result set logging an error.